### PR TITLE
Use base as target instead of latest

### DIFF
--- a/.github/workflows/tests-and-docker-images.yml
+++ b/.github/workflows/tests-and-docker-images.yml
@@ -38,4 +38,5 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           tags: ghcr.io/${{ github.repository }}:${{ github.head_ref || github.ref_name }}
+          target: base
           push: true


### PR DESCRIPTION
This pull request updates the Docker build process in the GitHub Actions workflow to specify a build target.

* [`.github/workflows/tests-and-docker-images.yml`](diffhunk://#diff-89d8e1d1d8741a7ac6b51729027d63d0c029bdbb3008e80dc9e9435e833c43e8R41): Added a `target` parameter with the value `base` to the Docker build step, ensuring that only the specified build stage is used.